### PR TITLE
Deploy json secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,18 @@ Where:
 
 * `pantheon_deploy.secrets` is a list of secrets to add to the Pantheon repository. Optional.
 
-Each item in `pantheon_deploy.secrets` has the following values:
+`pantheon_deploy.secrets` consists of the following forms:
 
+* `files` is for writing simple file secrets
+* `json` is for writing unicode json secrets
+
+Each item in `pantheon_deploy.secrets.file` has the following values:
 * `path` is the path to write the secret, relative to the root of the Pantheon repository. Required.
 * `value` is the value to write. Required.
+
+Each item in `pantheon_deploy.secrets.json` has the following values:
+* `path` is the same as the above.
+* `values` is all the items that are then encoded to JSON, this can be nested to create complex JSON files.
 
 When running this role from a CI system, you may have secrets available as environment variables. In that case, you can use the following to write them to the file:
 
@@ -111,8 +119,9 @@ When running this role from a CI system, you may have secrets available as envir
 pantheon_deploy:
 ...
   secrets:
-    - path: "web/private/secrets/super_secret_stuff.txt"
-      value: "{{ lookup('env', 'ENVVAR_FROM_CI') }}"
+    files:
+      - path: "web/private/secrets/super_secret_stuff.txt"
+        value: "{{ lookup('env', 'ENVVAR_FROM_CI') }}"
 ```
 
 As an added option you may export secrets in a JSON file:
@@ -236,6 +245,14 @@ Including an example of how to use your role (for instance, with variables passe
             repo_url: "ssh://codeserver.dev.abcd-ef12-3456-7890@codeserver.dev.abcd-ef12-3456-7890.drush.in:2222/~/repository.git"
             git_branch: 'master'
             git_commit_message: "Made with <3 by robots"
+          secrets:
+            files:
+              - path: 'path/to/file'
+                value: 'Hello world!'
+            json:
+              - path: 'path/to/json'
+                values:
+                  hello: "world"
       roles:
          - { role: ten7.pantheon_deploy }
 ```

--- a/README.md
+++ b/README.md
@@ -115,6 +115,25 @@ pantheon_deploy:
       value: "{{ lookup('env', 'ENVVAR_FROM_CI') }}"
 ```
 
+As an added option you may export secrets in a JSON file:
+
+```yaml
+pantheon_deploy:
+...
+  secrets:
+    json:
+      - path: "web/private/secrets/super_secret_data.json"
+        values:
+          secret_stuff: "stuff"
+          secret_things: "things"
+```
+
+Which would produce the following JSON:
+```json
+{"secret_stuff":"stuff","secret_things":"things"}
+```
+
+
 ### Post Deploy commands
 
 This role has the ability to execute Drush commands post deploy through `terminus`. 

--- a/README.md
+++ b/README.md
@@ -129,8 +129,12 @@ pantheon_deploy:
 ```
 
 Which would produce the following JSON:
+
 ```json
-{"secret_stuff":"stuff","secret_things":"things"}
+{
+  "secret_stuff"  : "stuff",
+  "secret_things" : "things"
+}
 ```
 
 

--- a/tasks/secrets.yml
+++ b/tasks/secrets.yml
@@ -1,24 +1,22 @@
 ---
-- name: Create directories for secrets
+- name: Create directories for secret files
   file:
     dest: "{{ _run_temp_dir.path }}/src/{{ item.path | dirname }}"
     state: directory
-  loop: "{{ pantheon_deploy.secrets  | default([]) }}"
-  when: pantheon_deploy.secrets.json is undefined
-- name: Create directories for JSON Secrets
+  loop: "{{ pantheon_deploy.secrets.files  | default([]) }}"
+- name: Create directories for secret JSON files
   file:
     dest: "{{ _run_temp_dir.path }}/src/{{ item.path | dirname }}"
     state: directory
-  loop: "{{ pantheon_deploy.secrets.json }}"
+  loop: "{{ pantheon_deploy.secrets.json | default([]) }}"
 - name: Write secrets
   copy:
     dest: "{{ _run_temp_dir.path }}/src/{{ item.path }}"
     content: "{{ item.value }}"
-  loop: "{{ pantheon_deploy.secrets | default([]) }}"
+  loop: "{{ pantheon_deploy.secrets.file | default([]) }}"
   when: item.value is defined
 - name: Write JSON secrets
   copy:
     dest: "{{ _run_temp_dir.path }}/src/{{ item.path }}"
     content: "{{ item.values | to_nice_json(indent=2, width=80, ensure_ascii=False) }}"
   loop: "{{ pantheon_deploy.secrets.json | default([]) }}"
-  when: pantheon_deploy.secrets.json is defined

--- a/tasks/secrets.yml
+++ b/tasks/secrets.yml
@@ -3,7 +3,13 @@
   file:
     dest: "{{ _run_temp_dir.path }}/src/{{ item.path | dirname }}"
     state: directory
-  loop: "{{ pantheon_deploy.secrets | default([]) }}"
+  loop: "{{ pantheon_deploy.secrets  | default([]) }}"
+  when: pantheon_deploy.secrets.json is undefined
+- name: Create directories for JSON Secrets
+  file:
+    dest: "{{ _run_temp_dir.path }}/src/{{ item.path | dirname }}"
+    state: directory
+  loop: "{{ pantheon_deploy.secrets.json }}"
 - name: Write secrets
   copy:
     dest: "{{ _run_temp_dir.path }}/src/{{ item.path }}"

--- a/tasks/secrets.yml
+++ b/tasks/secrets.yml
@@ -9,4 +9,10 @@
     dest: "{{ _run_temp_dir.path }}/src/{{ item.path }}"
     content: "{{ item.value }}"
   loop: "{{ pantheon_deploy.secrets | default([]) }}"
-
+  when: item.value is defined
+- name: Write JSON secrets
+  copy:
+    dest: "{{ _run_temp_dir.path }}/src/{{ item.path }}"
+    content: "{{ item.values | to_nice_json(indent=2, width=80, ensure_ascii=False) }}"
+  loop: "{{ pantheon_deploy.secrets.json | default([]) }}"
+  when: pantheon_deploy.secrets.json is defined


### PR DESCRIPTION
My first take at the basics of pushing JSON secrets to Pantheon, for consumption in Quicksilver scripts primarily.

  - Takes variables and formats them to unicode JSON.
  - Intended to function similarly to the existing secrets deployment task.
  - Includes loop to write multiple files if declared.