### PR TITLE
Add new features for builds to enable easier test pipelines

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -90,6 +90,8 @@
 
 - name: Work with npm
   include_tasks: "npm.yml"
+  when:
+    - pantheon_deploy.build.skip != true
 
 - name: Work with secrets
   include_tasks: "secrets.yml"
@@ -118,7 +120,20 @@
     _message: "{{ pantheon_deploy.target.git_commit_message | default('_pantheon_deploy_defaults.target.git_commit_message') }}"
   environment:
     GIT_SSH_COMMAND: "ssh -i {{ _run_temp_dir.path }}/id_ssh -o PubkeyAcceptedAlgorithms=+ssh-rsa -o HostkeyAlgorithms=+ssh-rsa"
-  when: ( _git_status.stdout | default('') != '' ) and ( 'nothing to commit, working tree clean' not in _git_status.stdout )
+  when: ( _git_status.stdout | default('') != '' ) and ( 'nothing to commit, working tree clean' not in _git_status.stdout ) and (pantheon_deploy.target.git_force_push != true)
+
+- name: Add, commit, and force push upstream changes
+  shell: >
+    git add -A &&
+    git commit -m "{{ _message }}" &&
+    git push -u origin {{ pantheon_deploy.target.git_branch }} --force
+  args:
+    chdir: "{{ _run_temp_dir.path }}/src/"
+  vars:
+    _message: "{{ pantheon_deploy.target.git_commit_message | default('_pantheon_deploy_defaults.target.git_commit_message') }}"
+  environment:
+    GIT_SSH_COMMAND: "ssh -i {{ _run_temp_dir.path }}/id_ssh -o PubkeyAcceptedAlgorithms=+ssh-rsa -o HostkeyAlgorithms=+ssh-rsa"
+  when: ( _git_status.stdout | default('') != '' ) and ( 'nothing to commit, working tree clean' not in _git_status.stdout ) and (pantheon_deploy.target.git_force_push == true)
 
 - name: Do post-deploy
   include_tasks: "postdeploy.yml"

--- a/tasks/npm.yml
+++ b/tasks/npm.yml
@@ -25,3 +25,14 @@
     chdir: "{{ _npm_dir }}"
   when:
     - _package_json.stat.exists == true
+  
+- name: Copy changes to source
+  ansible.posix.synchronize:
+    src: "{{ _run_temp_dir.path }}/src/"
+    dest: "{{ pantheon_deploy.source.git_dir }}/"
+    delete: no
+    archive: yes
+    rsync_opts: "--exclude=.git/"
+  delegate_to: localhost
+  when:
+    - pantheon_deploy.build.copy == true


### PR DESCRIPTION
  - Allows skipping the NPM build step 
      pantheon_deploy.build.skip = true
  - Copying the finished NPM build back to the source repo (for use in later CI pipeline steps) 
      pantheon_deploy.build.copy = true
  - Force pushing with Git by defining 
      pantheon_deploy.target.git_force_push = true