### PR TITLE
Allow defined build target directory

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,7 +30,7 @@
 - name: Create the defined directory to store files needed by the run
   file:
     state: directory
-    path: "{{ pantheon_deploy.source.build_dir }}"
+    path: "{{ pantheon_deploy.target.build_dir }}"
   register: _build_dir
   when:
     - ( pantheon_deploy.target.build_dir | default('') != '' ) and not ( _run_target_dir_stat.exists )

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,10 +12,32 @@
         "
 
 - name: Create a temp directory to store files needed by the run
+  notify: delete temp items
   tempfile:
     state: directory
     prefix: "pantheon-deploy-"
   register: _run_temp_dir
+  when:
+    - pantheon_deploy.target.build_dir | default('') == ''
+
+- name: Check for defined build directory
+  stat:
+    path: "{{ pantheon_deploy.target.build_dir }}"
+  register: _run_build_dir_stat
+  when:
+    - pantheon_deploy.target.build_dir | default('') != ''
+
+- name: Create the defined directory to store files needed by the run
+  file:
+    state: directory
+    path: "{{ pantheon_deploy.source.build_dir }}"
+  register: _build_dir
+  when:
+    - ( pantheon_deploy.target.build_dir | default('') != '' ) and not ( _run_target_dir_stat.exists )
+
+- name: Set target build directory
+  set_fact:
+    _run_dir: _build_dir.path | default(_run_temp_dir.path)
 
 - name: Copy the key to the temp dir
   copy:
@@ -24,9 +46,9 @@
     mode: "0600"
   loop:
     - data: "{{ pantheon_deploy.target.ssh_key_base64 }}"
-      dest: "{{ _run_temp_dir.path }}/id_ssh"
+      dest: "{{ _run_dir }}/id_ssh"
     - data: "{{ pantheon_deploy.target.ssh_pub_base64 }}"
-      dest: "{{ _run_temp_dir.path }}/id_ssh.pub"
+      dest: "{{ _run_dir }}/id_ssh.pub"
   no_log: "{{ pantheon_deploy.debug | default(true) | bool }}"
 
 - name: Check if the target branch exists
@@ -34,21 +56,21 @@
     git ls-remote --exit-code --heads {{ pantheon_deploy.target.repo_url }} {{ pantheon_deploy.target.git_branch }}
   ignore_errors: yes
   environment:
-    GIT_SSH_COMMAND: "ssh -i {{ _run_temp_dir.path }}/id_ssh -o StrictHostKeyChecking=accept-new -o PubkeyAcceptedAlgorithms=+ssh-rsa -o HostkeyAlgorithms=+ssh-rsa"
+    GIT_SSH_COMMAND: "ssh -i {{ _run_dir }}/id_ssh -o StrictHostKeyChecking=accept-new -o PubkeyAcceptedAlgorithms=+ssh-rsa -o HostkeyAlgorithms=+ssh-rsa"
   register: _target_branch_exists
 
 - name: Clone branch from upstream
   ansible.builtin.git:
     repo: "{{ pantheon_deploy.target.repo_url }}"
-    dest: "{{ _run_temp_dir.path }}/src"
+    dest: "{{ _run_dir }}/src"
     clone: yes
     force: yes
     recursive: yes
     bare: no
     update: yes
     accept_hostkey: yes
-    ssh_opts: "-o IdentityFile={{ _run_temp_dir.path }}/id_ssh -o PubkeyAcceptedAlgorithms=+ssh-rsa -o HostkeyAlgorithms=+ssh-rsa"
-    key_file: "{{ _run_temp_dir.path }}/id_ssh"
+    ssh_opts: "-o IdentityFile={{ _run_dir }}/id_ssh -o PubkeyAcceptedAlgorithms=+ssh-rsa -o HostkeyAlgorithms=+ssh-rsa"
+    key_file: "{{ _run_dir }}/id_ssh"
     version: "{% if _target_branch_exists.rc == 0 %}\
               {{ pantheon_deploy.target.git_branch }}\
               {% else %}\
@@ -61,17 +83,17 @@
   shell: >
     git switch -C {{ pantheon_deploy.source.git_branch }}
   args:
-    chdir: "{{ _run_temp_dir.path }}/src/"
+    chdir: "{{ _run_dir }}/src/"
   when:
     - _target_branch_exists.rc != 0
   environment:
-    GIT_SSH_COMMAND: "ssh -i {{ _run_temp_dir.path }}/id_ssh -o PubkeyAcceptedAlgorithms=+ssh-rsa -o HostkeyAlgorithms=+ssh-rsa"
+    GIT_SSH_COMMAND: "ssh -i {{ _run_dir }}/id_ssh -o PubkeyAcceptedAlgorithms=+ssh-rsa -o HostkeyAlgorithms=+ssh-rsa"
 
 - name: Copy changes to upstream
   ansible.posix.synchronize:
     src: "{{ pantheon_deploy.source.git_dir }}/"
-    dest: "{{ _run_temp_dir.path }}/src/"
-    delete: yes
+    dest: "{{ _run_dir }}/src/"
+    delete: {{ pantheon_deploy.target.clone_delete | default('yes') }}
     archive: yes
     rsync_opts: "--exclude=.git/"
   delegate_to: localhost
@@ -84,7 +106,7 @@
 - name: Overwrite .gitignore on target if .gitignore-pantheon exists
   copy:
     src: "{{ pantheon_deploy.source.git_dir }}/.gitignore-pantheon"
-    dest: "{{ _run_temp_dir.path }}/src/.gitignore"
+    dest: "{{ _run_dir }}/src/.gitignore"
   when:
     - _gitignore_pantheon.stat.exists == true
 
@@ -106,7 +128,7 @@
   shell: >
     git status --porcelain
   args:
-    chdir: "{{ _run_temp_dir.path }}/src/"
+    chdir: "{{ _run_dir }}/src/"
   register: _git_status
 
 - name: Add, commit, and push upstream if changes
@@ -115,11 +137,11 @@
     git commit -m "{{ _message }}" &&
     git push -u origin {{ pantheon_deploy.target.git_branch }}
   args:
-    chdir: "{{ _run_temp_dir.path }}/src/"
+    chdir: "{{ _run_dir }}/src/"
   vars:
     _message: "{{ pantheon_deploy.target.git_commit_message | default('_pantheon_deploy_defaults.target.git_commit_message') }}"
   environment:
-    GIT_SSH_COMMAND: "ssh -i {{ _run_temp_dir.path }}/id_ssh -o PubkeyAcceptedAlgorithms=+ssh-rsa -o HostkeyAlgorithms=+ssh-rsa"
+    GIT_SSH_COMMAND: "ssh -i {{ _run_dir }}/id_ssh -o PubkeyAcceptedAlgorithms=+ssh-rsa -o HostkeyAlgorithms=+ssh-rsa"
   when: ( _git_status.stdout | default('') != '' ) and ( 'nothing to commit, working tree clean' not in _git_status.stdout ) and (pantheon_deploy.target.git_force_push | default(true) != true)
 
 - name: Add, commit, and force push upstream changes
@@ -128,11 +150,11 @@
     git commit -m "{{ _message }}" &&
     git push -u origin {{ pantheon_deploy.target.git_branch }} --force
   args:
-    chdir: "{{ _run_temp_dir.path }}/src/"
+    chdir: "{{ _run_dir }}/src/"
   vars:
     _message: "{{ pantheon_deploy.target.git_commit_message | default('_pantheon_deploy_defaults.target.git_commit_message') }}"
   environment:
-    GIT_SSH_COMMAND: "ssh -i {{ _run_temp_dir.path }}/id_ssh -o PubkeyAcceptedAlgorithms=+ssh-rsa -o HostkeyAlgorithms=+ssh-rsa"
+    GIT_SSH_COMMAND: "ssh -i {{ _run_dir }}/id_ssh -o PubkeyAcceptedAlgorithms=+ssh-rsa -o HostkeyAlgorithms=+ssh-rsa"
   when: ( _git_status.stdout | default('') != '' ) and ( 'nothing to commit, working tree clean' not in _git_status.stdout ) and (pantheon_deploy.target.git_force_push | default(true) == true)
 
 - name: Do post-deploy

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -113,7 +113,7 @@
 - name: Work with npm
   include_tasks: "npm.yml"
   when:
-    - pantheon_deploy.build.skip != true
+    - pantheon_deploy.build.skip | default(false) != true
 
 - name: Work with secrets
   include_tasks: "secrets.yml"

--- a/tasks/npm.yml
+++ b/tasks/npm.yml
@@ -2,7 +2,7 @@
 - name: Generate the npm directory path
   set_fact:
     _npm_dir: "\
-      {{ _run_temp_dir.path }}/src\
+      {{ _run_dir }}/src\
       {% if pantheon_deploy.build.npm_dir is defined %}\
       /{{ pantheon_deploy.build.npm_dir }}\
       {% endif %}"
@@ -25,14 +25,3 @@
     chdir: "{{ _npm_dir }}"
   when:
     - _package_json.stat.exists == true
-  
-- name: Copy changes to source
-  ansible.posix.synchronize:
-    src: "{{ _run_temp_dir.path }}/src/"
-    dest: "{{ pantheon_deploy.source.git_dir }}/"
-    delete: no
-    archive: yes
-    rsync_opts: "--exclude=.git/"
-  delegate_to: localhost
-  when:
-    - pantheon_deploy.build.copy == true

--- a/tasks/postdeploy.yml
+++ b/tasks/postdeploy.yml
@@ -11,7 +11,7 @@
   shell: >
     terminus auth:login --machine-token={{ pantheon_deploy.target.machine_token | default('') }}
   environment:
-    TERMINUS_SSH_COMMAND: "ssh -i {{ _run_temp_dir.path }}/id_ssh -o PubkeyAcceptedAlgorithms=+ssh-rsa -o HostkeyAlgorithms=+ssh-rsa"
+    TERMINUS_SSH_COMMAND: "ssh -i {{ _run_dir }}/id_ssh -o PubkeyAcceptedAlgorithms=+ssh-rsa -o HostkeyAlgorithms=+ssh-rsa"
   timeout: 30
   
 - name: Check the status of workflows
@@ -32,7 +32,7 @@
   retries: 20
   delay: 15
   environment:
-    TERMINUS_SSH_COMMAND: "ssh -i {{ _run_temp_dir.path }}/id_ssh -o PubkeyAcceptedAlgorithms=+ssh-rsa -o HostkeyAlgorithms=+ssh-rsa"
+    TERMINUS_SSH_COMMAND: "ssh -i {{ _run_dir }}/id_ssh -o PubkeyAcceptedAlgorithms=+ssh-rsa -o HostkeyAlgorithms=+ssh-rsa"
   timeout: 30
   
 - shell: >

--- a/tasks/secrets.yml
+++ b/tasks/secrets.yml
@@ -1,12 +1,12 @@
 ---
 - name: Create directories for secrets
   file:
-    dest: "{{ _run_temp_dir.path }}/src/{{ item.path | dirname }}"
+    dest: "{{ _run_dir }}/src/{{ item.path | dirname }}"
     state: directory
   loop: "{{ pantheon_deploy.secrets | default([]) }}"
 - name: Write secrets
   copy:
-    dest: "{{ _run_temp_dir.path }}/src/{{ item.path }}"
+    dest: "{{ _run_dir.path }}/src/{{ item.path }}"
     content: "{{ item.value }}"
   loop: "{{ pantheon_deploy.secrets | default([]) }}"
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,6 +7,8 @@ _pantheon_deploy_defaults:
     npm_dir: ''
     npm_build_script_name: 'build'
   target:
+    clone_delete: yes
+    build_dir: ''
     ssh_key_base64: ''
     ssh_pub_base64: ''
     pantheon_machine_token: ''

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,6 +6,7 @@ _pantheon_deploy_defaults:
   build:
     npm_dir: ''
     npm_build_script_name: 'build'
+    skip: false
   target:
     clone_delete: yes
     build_dir: ''


### PR DESCRIPTION
  - Allows defining a build directory with pantheon_deploy.target.build_dir
  - Refactors the playbook to use that defined directory or, create a temp directory
  - This build run directory is then stored in _run_dir as the path itself, regardless of whether its defined or temp.
  - It also allows skipping the ansible synchronize delete step with pantheon_deploy.target.clone_delete