### PR TITLE
Revert broken experimental changes to allow the role to work

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,35 +17,10 @@
     state: directory
     prefix: "pantheon-deploy-"
   register: _run_temp_dir
-  when:
-    - pantheon_deploy.target.build_dir | default('') == ''
 
-- name: Check for defined build directory
-  stat:
-    path: "{{ pantheon_deploy.target.build_dir }}"
-  register: _run_target_dir_stat
-  when:
-    - pantheon_deploy.target.build_dir | default('') != ''
-
-- name: Create the defined directory to store files needed by the run
-  file:
-    state: directory
-    path: "{{ pantheon_deploy.target.build_dir }}"
-  register: _build_dir
-  when:
-    - ( pantheon_deploy.target.build_dir | default('') != '' ) and not ( _run_target_dir_stat.stat.exists )
-
-- name: Set target build directory if defined
-  set_fact:
-    _run_dir: "{{ _build_dir.path }}"
-  when:
-    - _build_dir | default('') != ''
-
-- name: Set target build directory if temp
+- name: Set target build directory
   set_fact:
     _run_dir: "{{ _run_temp_dir.path }}"
-  when:
-    - _run_temp_dir | default('') != ''
 
 - name: Copy the key to the temp dir
   copy:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -9,7 +9,6 @@ _pantheon_deploy_defaults:
     skip: false
   target:
     clone_delete: yes
-    build_dir: ''
     ssh_key_base64: ''
     ssh_pub_base64: ''
     pantheon_machine_token: ''


### PR DESCRIPTION
  - This undoes the change to allow a defined build directory.
  - This leaves in the change to allow force pushing, if defined.